### PR TITLE
:bug: Fix build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ COPY configuration.py /etc/netbox/config/configuration.py
 RUN apt update && apt install -y build-essential
 RUN /opt/netbox/venv/bin/pip install --no-cache-dir netbox-secretstore
 RUN apt purge -y build-essential
-RUN SECRET_KEY="dummy" /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py collectstatic --no-input
+RUN SECRET_KEY="bnxaRYYpmf5dZqDLNbLnNhXnXREMi5W8L9P8JWBKqj9wXxIswz" /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py collectstatic --no-input

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.4'
 services:
   netbox: &netbox
     image: quay.io/chaosdorf/netbox:add-secretstore-plugin
+    build: .
     depends_on:
     - postgres
     - redis


### PR DESCRIPTION
Apparently, the secret key needs to be at least 50 characters long. We need it for the `collectstatic` command to run, even though its meaningless at this point. The secret key will be another one when running the application.